### PR TITLE
Improve Docker build reporting

### DIFF
--- a/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/test_run.sh.j2
+++ b/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/test_run.sh.j2
@@ -24,7 +24,7 @@ fi
 echo "=+= (Re)build the container"
 docker build "$SCRIPT_DIR" \
   --platform=linux/amd64 \
-  --tag $DOCKER_TAG
+  --tag $DOCKER_TAG 2>&1
 
 
 echo "=+= Doing a forward pass"

--- a/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/test_run.sh.j2
+++ b/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/test_run.sh.j2
@@ -24,7 +24,6 @@ fi
 echo "=+= (Re)build the container"
 docker build "$SCRIPT_DIR" \
   --platform=linux/amd64 \
-  --quiet \
   --tag $DOCKER_TAG
 
 

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/test_run.sh.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/test_run.sh.j2
@@ -24,7 +24,6 @@ fi
 echo "=+= (Re)build the container"
 docker build "$SCRIPT_DIR" \
   --platform=linux/amd64 \
-  --quiet \
   --tag $DOCKER_TAG
 
 

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/test_run.sh.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/test_run.sh.j2
@@ -24,7 +24,7 @@ fi
 echo "=+= (Re)build the container"
 docker build "$SCRIPT_DIR" \
   --platform=linux/amd64 \
-  --tag $DOCKER_TAG
+  --tag $DOCKER_TAG 2>&1
 
 
 echo "=+= Doing an evaluation"


### PR DESCRIPTION
When loading the example-algorithm, based on the pytorch image. A layer of 4GB needs to be pulled and extracted. This takes more than a few minutes on some systems.

In turn, it makes it seem like nothing is going on and the test run for users has just stalled. 

This change ensures that the docker build is more informative about what is going on.

At the same time, it ensures that when forge is called in debug mode, the script output is also shown as to status report on what is going on.

Finally, it redirects stderr to stdout because the test-script stderr is used for quality control checking.