### PR TITLE
Multithreading Improvements

### DIFF
--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/Dockerfile
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/Dockerfile
@@ -20,4 +20,7 @@ RUN python -m pip install \
 
 COPY --chown=user:user evaluate.py /opt/app/
 
+# Setting this will limit the number of workers used by the evaluate.py
+ENV GRAND_CHALLENGE_MAX_WORKERS=
+
 ENTRYPOINT ["python", "evaluate.py"]

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/Dockerfile
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/Dockerfile
@@ -18,6 +18,7 @@ RUN python -m pip install \
     --no-color \
     --requirement /opt/app/requirements.txt
 
+COPY --chown=user:user helpers.py /opt/app/
 COPY --chown=user:user evaluate.py /opt/app/
 
 # Setting this will limit the number of workers used by the evaluate.py

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/evaluate.py.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/evaluate.py.j2
@@ -25,10 +25,10 @@ from glob import glob
 import SimpleITK
 {%- endif %}
 import random
-from multiprocessing import Pool
 from statistics import mean
 from pathlib import Path
 from pprint import pformat, pprint
+from concurrent.futures import ThreadPoolExecutor
 
 
 INPUT_DIRECTORY = Path("/input")
@@ -40,7 +40,7 @@ GROUND_TRUTH_DIRECTORY = Path("ground_truth")
 # To limit this, update the Dockerfile GRAND_CHALLENGE_MAX_WORKERS
 environ_cpu_limit = os.getenv("GRAND_CHALLENGE_MAX_WORKERS")
 cpu_count = multiprocessing.cpu_count()
-NUM_PROCESSES = min(
+MAX_WORKERS = min(
     [
         int(environ_cpu_limit or cpu_count),
         cpu_count,
@@ -58,12 +58,12 @@ def main():
     # Note that the jobs are not in any order!
     # We work that out from predictions.json
 
-    # Start a number of process workers, using multiprocessing
+    # Use threaded workers to process the predictions more efficiently
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        metrics["results"] = list(executor.map(process, predictions))
 
-    with Pool(processes=NUM_PROCESSES) as pool:
-        metrics["results"] = pool.map(process, predictions)
-
-    # Now generate an overall score(s) for this submission
+    # We have the results per prediction, we can aggregate over the results and
+    # generate an overall score(s) for this submission
     metrics["aggregates"] = {
         "my_metric": mean(result["my_metric"] for result in metrics["results"])
     }
@@ -79,6 +79,7 @@ def process(job):
     report = "Processing:\n"
     report += pformat(job)
     report += "\n"
+
 
 
     # Firstly, find the location of the results

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/evaluate.py.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/evaluate.py.j2
@@ -18,8 +18,6 @@ Any container that shows the same behavior will do, this is purely an example of
 Happy programming!
 """
 import json
-import multiprocessing
-import os
 {% if cookiecutter.phase.algorithm_inputs | has_image -%}
 from glob import glob
 import SimpleITK
@@ -28,61 +26,23 @@ import random
 from statistics import mean
 from pathlib import Path
 from pprint import pformat, pprint
-from concurrent.futures import ThreadPoolExecutor
-
+from helpers import run_prediction_processing
 
 INPUT_DIRECTORY = Path("/input")
 OUTPUT_DIRECTORY = Path("/output")
 GROUND_TRUTH_DIRECTORY = Path("ground_truth")
 
-# The optimal number of workers ultimately depends on how many
-# resources each process would call upon.
-# To limit this, update the Dockerfile GRAND_CHALLENGE_MAX_WORKERS
-environ_cpu_limit = os.getenv("GRAND_CHALLENGE_MAX_WORKERS")
-cpu_count = multiprocessing.cpu_count()
-MAX_WORKERS = min(
-    [
-        int(environ_cpu_limit or cpu_count),
-        cpu_count,
-    ]
-)
+
 
 {% if "__should_fail" in cookiecutter.phase -%} 1/0 {%- endif %}
-def main():
-    print_inputs()
-
-    metrics = {}
-    predictions = read_predictions()
-
-    # We now process each algorithm job for this submission
-    # Note that the jobs are not in any order!
-    # We work that out from predictions.json
-
-    # Use threaded workers to process the predictions more efficiently
-    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-        metrics["results"] = list(executor.map(process, predictions))
-
-    # We have the results per prediction, we can aggregate over the results and
-    # generate an overall score(s) for this submission
-    metrics["aggregates"] = {
-        "my_metric": mean(result["my_metric"] for result in metrics["results"])
-    }
-
-    # Make sure to save the metrics
-    write_metrics(metrics=metrics)
-
-    return 0
-
 
 def process(job):
-    # Processes a single algorithm job, looking at the outputs
+    """Processes a single algorithm job, looking at the outputs"""
     report = "Processing:\n"
     report += pformat(job)
     report += "\n"
 
-
-
-    # Firstly, find the location of the results
+      # Firstly, find the location of the results
     {% for ci in cookiecutter.phase.algorithm_outputs %}
     {%- set py_slug = ci.slug | replace("-", "_") -%}
     location_{{ py_slug }} = get_file_location(
@@ -124,7 +84,7 @@ def process(job):
     {% endif -%}
     {%- endfor %}
 
-    # Fourthly, your load your ground truth
+    # Fourthly, load your ground truth
     # Include it in your evaluation container by placing it in ground_truth/
     with open(GROUND_TRUTH_DIRECTORY / "some_resource.txt", "r") as f:
         report += f.read()
@@ -137,6 +97,30 @@ def process(job):
     return {
         "my_metric": random.choice([1, 0]),
     }
+
+def main():
+    print_inputs()
+
+    metrics = {}
+    predictions = read_predictions()
+
+    # We now process each algorithm job for this submission
+    # Note that the jobs are not in any order!
+    # We work that out from predictions.json
+
+    # Use concurrent workers to process the predictions more efficiently
+    metrics["results"] = run_prediction_processing(fn=process, predictions=predictions)
+
+    # We have the results per prediction, we can aggregate over the results and
+    # generate an overall score(s) for this submission
+    metrics["aggregates"] = {
+        "my_metric": mean(result["my_metric"] for result in metrics["results"])
+    }
+
+    # Make sure to save the metrics
+    write_metrics(metrics=metrics)
+
+    return 0
 
 
 def print_inputs():

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/evaluate.py.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/evaluate.py.j2
@@ -18,6 +18,8 @@ Any container that shows the same behavior will do, this is purely an example of
 Happy programming!
 """
 import json
+import multiprocessing
+import os
 {% if cookiecutter.phase.algorithm_inputs | has_image -%}
 from glob import glob
 import SimpleITK
@@ -33,6 +35,18 @@ INPUT_DIRECTORY = Path("/input")
 OUTPUT_DIRECTORY = Path("/output")
 GROUND_TRUTH_DIRECTORY = Path("ground_truth")
 
+# The optimal number of workers ultimately depends on how many
+# resources each process would call upon.
+# To limit this, update the Dockerfile GRAND_CHALLENGE_MAX_WORKERS
+environ_cpu_limit = os.getenv("GRAND_CHALLENGE_MAX_WORKERS")
+cpu_count = multiprocessing.cpu_count()
+NUM_PROCESSES = min(
+    [
+        int(environ_cpu_limit or cpu_count),
+        cpu_count,
+    ]
+)
+
 {% if "__should_fail" in cookiecutter.phase -%} 1/0 {%- endif %}
 def main():
     print_inputs()
@@ -45,9 +59,8 @@ def main():
     # We work that out from predictions.json
 
     # Start a number of process workers, using multiprocessing
-    # The optimal number of workers ultimately depends on how many
-    # resources each process() would call upon
-    with Pool(processes=4) as pool:
+
+    with Pool(processes=NUM_PROCESSES) as pool:
         metrics["results"] = pool.map(process, predictions)
 
     # Now generate an overall score(s) for this submission

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/helpers.py
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/helpers.py
@@ -1,0 +1,133 @@
+import multiprocessing
+import os
+import signal
+from concurrent.futures import as_completed
+from multiprocessing import Manager, Process
+
+import psutil
+from pebble import ProcessPool
+
+
+class PredictionProcessingError(RuntimeError):
+    def __init__(self, prediction):
+        self.prediction = prediction
+
+    def __str__(self):
+        return f"Error for prediction: {self.prediction}"
+
+
+def get_max_workers():
+    """
+    Returns the maximum number of concurrent workers
+
+    The optimal number of workers ultimately depends on how many resources
+    each process will call upon.
+
+    To limit this, update the Dockerfile GRAND_CHALLENGE_MAX_WORKERS
+    """
+
+    environ_cpu_limit = os.getenv("GRAND_CHALLENGE_MAX_WORKERS")
+    cpu_count = multiprocessing.cpu_count()
+    return min(
+        [
+            int(environ_cpu_limit or cpu_count),
+            cpu_count,
+        ]
+    )
+
+
+def run_prediction_processing(*, fn, predictions):
+    """
+    Processes predictions in separate processes.
+
+    This takes child processes into account:
+    - if any child process is terminated, all prediction processing will abort
+    - after prediction processing is done, all child processes are terminated
+
+    Parameters
+    ----------
+    fn : function
+        Function to execute.
+
+    predictions : list
+        List of predictions.
+
+    """
+    with Manager() as manager:
+        results = manager.list()
+        errors = manager.list()
+
+        process = Process(
+            target=__pool_worker,
+            name="PredictionProcessing",
+            kwargs=dict(
+                fn=fn,
+                predictions=predictions,
+                max_workers=get_max_workers(),
+                results=results,
+                errors=errors,
+            ),
+        )
+        try:
+            process.start()
+            process.join()
+        finally:
+            process.close()
+
+        for prediction, e in errors:
+            raise PredictionProcessingError(prediction=prediction) from e
+
+        return list(results)
+
+
+def __pool_worker(*, fn, predictions, max_workers, results, errors):
+    terminating_child_processes = False
+    with ProcessPool(max_workers=max_workers) as pool:
+        try:
+
+            def sigchld_handler(*_, **__):
+                if not terminating_child_processes:
+                    pool.stop()
+                    raise RuntimeError(
+                        "Child process was terminated unexpectedly"
+                    )
+
+            # Register the SIGCHLD handler
+            signal.signal(signal.SIGCHLD, sigchld_handler)
+
+            # Submit the processing tasks of the predictions
+            futures = [
+                pool.schedule(fn, [prediction]) for prediction in predictions
+            ]
+            future_to_predictions = {
+                future: item
+                for future, item in zip(futures, predictions, strict=True)
+            }
+
+            for future in as_completed(future_to_predictions):
+                try:
+                    result = future.result()
+                except Exception as e:
+                    for f in futures:
+                        f.cancel()
+                    pool.stop()
+                    errors.append((future_to_predictions[future], e))
+                results.append(result)
+        finally:
+            terminating_child_processes = True
+            terminate_child_processes()
+
+
+def terminate_child_processes():
+    current_process = psutil.Process(os.getpid())
+    children = current_process.children(recursive=True)
+    for child in children:
+        child.terminate()
+
+    # Wait for processes to terminate
+    gone, still_alive = psutil.wait_procs(children, timeout=5)
+
+    # Forcefully kill any remaining processes
+    for p in still_alive:
+        print(f"Forcefully killing child process {p.pid}")
+        p.kill()

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/helpers.py
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/helpers.py
@@ -101,11 +101,11 @@ def _start_pool_worker(fn, predictions, max_workers, results, errors):
 def _pool_worker(*, fn, predictions, max_workers, results, errors):
     terminating_child_processes = False
 
-    with ProcessPoolExecutor(max_workers=max_workers) as pool:
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
         try:
 
             def handle_error(error, prediction="Unknown"):
-                pool.shutdown(wait=False, cancel_futures=True)
+                executor.shutdown(wait=False, cancel_futures=True)
                 errors.append((prediction, error))
 
                 nonlocal terminating_child_processes
@@ -125,7 +125,7 @@ def _pool_worker(*, fn, predictions, max_workers, results, errors):
 
             # Submit the processing tasks of the predictions
             futures = [
-                pool.submit(fn, prediction) for prediction in predictions
+                executor.submit(fn, prediction) for prediction in predictions
             ]
             future_to_predictions = {
                 future: item

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/requirements.txt.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/requirements.txt.j2
@@ -2,5 +2,4 @@
 SimpleITK
 numpy
 {%- endif %}
-pebble
 psutil

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/requirements.txt.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/requirements.txt.j2
@@ -2,3 +2,5 @@
 SimpleITK
 numpy
 {%- endif %}
+pebble
+psutil

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,13 @@ grand-challenge-forge = "grand_challenge_forge.cli:cli"
 python = "^3.10"
 cookiecutter = "^2.5.0"
 click = "*"
-
-
 jsonschema = "^4.20.0"
-
 
 [tool.poetry.dev-dependencies]
 pytest = "*"
 pytest-xdist = "*"
+psutil = "^5.9.8"
+pytest-timeout = "^2.3.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_evaluate_helpers.py
+++ b/tests/test_evaluate_helpers.py
@@ -84,15 +84,13 @@ def test_prediction_processing_error():
 
 @pytest.mark.timeout(5)
 def test_prediction_processing_killing_of_child_processes():
-    # Firstly, we need to start somethings that spawns child processes
-
     predictions = ["prediction1", "prediction2"]
     result = run_prediction_processing(
         fn=child_spawning_process, predictions=predictions
     )
 
-    # The above call returning already shows that it correctly kill
-    # child processes, for sanity:
+    # The above call returning already shows that it correctly terminates
+    # child processes, just for sanity:
     assert len(result) == len(predictions)
 
 

--- a/tests/test_evaluate_helpers.py
+++ b/tests/test_evaluate_helpers.py
@@ -25,6 +25,10 @@ from helpers import (  # noqa: E402
     run_prediction_processing,
 )
 
+# Some of the test below, if things go wrong, can potentially deadlock.
+# So we set a maximum runtime
+pytestmark = pytest.mark.timeout(5)
+
 
 def working_process(p):
     return f"{p} result"
@@ -82,8 +86,10 @@ def test_prediction_processing_error():
     assert excinfo.value.prediction in predictions
 
 
-@pytest.mark.timeout(5)
 def test_prediction_processing_killing_of_child_processes():
+    # If something goes wrong, this test could deadlock
+    # 5 seconds should be more than enough
+
     predictions = ["prediction1", "prediction2"]
     result = run_prediction_processing(
         fn=child_spawning_process, predictions=predictions
@@ -94,7 +100,6 @@ def test_prediction_processing_killing_of_child_processes():
     assert len(result) == len(predictions)
 
 
-@pytest.mark.timeout(5)
 def test_prediction_processing_catching_killing_of_child_processes():
     predictions = ["prediction1", "prediction2"]
 

--- a/tests/test_evaluate_helpers.py
+++ b/tests/test_evaluate_helpers.py
@@ -1,0 +1,129 @@
+import os
+import signal
+import sys
+import time
+from functools import partial
+from multiprocessing import Process
+from unittest import mock
+
+import pytest
+
+# Do some creating path hacking to be able to import the helpers
+parent_dir = os.path.abspath(
+    os.path.join(
+        "grand_challenge_forge",
+        "partials",
+        "example-evaluation-method",
+        "example-evaluation-method{{cookiecutter._}}",
+    )
+)
+sys.path.insert(0, parent_dir)
+
+from helpers import (  # noqa: E402
+    PredictionProcessingError,
+    _start_pool_worker,
+    run_prediction_processing,
+)
+
+
+def working_process(p):
+    return f"{p} result"
+
+
+def failing_process(*_):
+    raise RuntimeError("You have failed me for the last time")
+
+
+def child_process():
+    while True:
+        print("Child busy")
+        time.sleep(1)
+
+
+def child_spawning_process(*_):
+    child = Process(target=child_process)
+    child.start()
+    return "Done"
+
+
+def forever_process(*_):
+    while True:
+        time.sleep(1)
+
+
+def send_signals_to_process(process, signal_to_send, interval):
+    while True:
+        try:
+            os.kill(process.pid, signal_to_send)
+        except ProcessLookupError:
+            # Race conditions sometimes have this try and send a signal even though
+            # the process is already terminated
+            pass
+        time.sleep(interval)
+
+
+def test_prediction_processing():
+    predictions = ["prediction1", "prediction2"]
+    result = run_prediction_processing(
+        fn=working_process, predictions=predictions
+    )
+    assert ["prediction1 result", "prediction2 result"] == result
+
+
+def test_prediction_processing_error():
+    predictions = ["prediction"]  # Use one prediction for reproducibility
+    with pytest.raises(PredictionProcessingError) as excinfo:
+        run_prediction_processing(fn=failing_process, predictions=predictions)
+
+    assert (
+        "Error for prediction prediction: You have failed me for the last time"
+        in str(excinfo.value)
+    )
+    assert excinfo.value.prediction in predictions
+
+
+@pytest.mark.timeout(5)
+def test_prediction_processing_killing_of_child_processes():
+    # Firstly, we need to start somethings that spawns child processes
+
+    predictions = ["prediction1", "prediction2"]
+    result = run_prediction_processing(
+        fn=child_spawning_process, predictions=predictions
+    )
+
+    # The above call returning already shows that it correctly kill
+    # child processes, for sanity:
+    assert len(result) == len(predictions)
+
+
+@pytest.mark.timeout(5)
+def test_prediction_processing_catching_killing_of_child_processes():
+    predictions = ["prediction1", "prediction2"]
+
+    child_terminator = None
+
+    # Set up the fake child murder scene
+    def add_child_terminator(*args, **kwargs):
+        process = _start_pool_worker(*args, **kwargs)
+        nonlocal child_terminator
+        child_terminator = Process(
+            target=partial(
+                send_signals_to_process, process, signal.SIGCHLD, 0.5
+            )
+        )
+        child_terminator.start()  # Hasta la vista, baby
+        return process
+
+    try:
+        with mock.patch("helpers._start_pool_worker", add_child_terminator):
+            with pytest.raises(PredictionProcessingError) as excinfo:
+                run_prediction_processing(
+                    fn=forever_process, predictions=predictions
+                )
+    finally:
+        if child_terminator:
+            child_terminator.terminate()
+
+    assert "Child process was terminated unexpectedly" in str(
+        excinfo.value.error
+    )


### PR DESCRIPTION
Closes: https://github.com/DIAGNijmegen/rse-grand-challenge-forge/issues/40

This PR improves the multithreading used in the evaluation:

- Dynamically adjust the number of workers on the CPUs available.
- Use `concurrent.futures.ThreadPoolExecutor` instead of `multiprocessing.Pool` to push all threads under a single process. This should prevent random killed threads/processes from stalling the run.
