### PR TITLE
Fix using not mac compatible mkdir call

### DIFF
--- a/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/test_run.sh.j2
+++ b/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/test_run.sh.j2
@@ -18,7 +18,7 @@ if [ -d "$OUTPUT_DIR" ]; then
   rm -rf "${OUTPUT_DIR}"/*
   chmod -f o+rwx "$OUTPUT_DIR"
 else
-  mkdir --mode=o+rwx "$OUTPUT_DIR"
+  mkdir -m=o+rwx "$OUTPUT_DIR"
 fi
 
 

--- a/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/test_run.sh.j2
+++ b/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/test_run.sh.j2
@@ -18,7 +18,7 @@ if [ -d "$OUTPUT_DIR" ]; then
   rm -rf "${OUTPUT_DIR}"/*
   chmod -f o+rwx "$OUTPUT_DIR"
 else
-  mkdir -m=o+rwx "$OUTPUT_DIR"
+  mkdir -m o+rwx "$OUTPUT_DIR"
 fi
 
 

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/test_run.sh.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/test_run.sh.j2
@@ -18,7 +18,7 @@ if [ -d "$OUTPUT_DIR" ]; then
   rm -rf "${OUTPUT_DIR}"/*
   chmod -f o+rwx "$OUTPUT_DIR"
 else
-  mkdir --mode=o+rwx "$OUTPUT_DIR"
+  mkdir -m=o+rwx "$OUTPUT_DIR"
 fi
 
 

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/test_run.sh.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/test_run.sh.j2
@@ -18,7 +18,7 @@ if [ -d "$OUTPUT_DIR" ]; then
   rm -rf "${OUTPUT_DIR}"/*
   chmod -f o+rwx "$OUTPUT_DIR"
 else
-  mkdir -m=o+rwx "$OUTPUT_DIR"
+  mkdir -m o+rwx "$OUTPUT_DIR"
 fi
 
 


### PR DESCRIPTION
It turns out that macs `mkdir` don't per see have `--mode`. So replace it with the shorthand notation (`-m`) it for compact sake.