### PR TITLE
Load file inputs for algorithm and extract file name for evaluation

### DIFF
--- a/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/inference.py.j2
+++ b/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/inference.py.j2
@@ -47,6 +47,11 @@ def run():
          location=INPUT_PATH / "{{ ci.relative_path }}",
     )
     {% endif -%}
+    {% if ci | is_file -%}
+    input_{{ py_slug }} = load_file(
+         location=INPUT_PATH / "{{ ci.relative_path }}",
+    )
+    {% endif -%}
     {% endfor %}
     # Process the inputs: any way you'd like
     _show_torch_cuda_info()
@@ -54,7 +59,7 @@ def run():
     with open(RESOURCE_PATH / "some_resource.txt", "r") as f:
         print(f.read())
 
-    # For now, let us set make bogus predictions
+    # For now, let us make bogus predictions
     {%- for ci in cookiecutter.phase.algorithm_outputs %}
     output_{{ ci.slug | replace("-", "_")}} =
         {%- if ci | is_image %} numpy.eye(4, 2)

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/evaluate.py.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/evaluate.py.j2
@@ -73,11 +73,17 @@ def process(job):
     {%- endfor %}
 
 
-    # Thirdly, retrieve the input image name to match it with an image in your ground truth
+    # Thirdly, retrieve the input file name to match it with your ground truth
     {% for ci in cookiecutter.phase.algorithm_inputs -%}
     {% set py_slug = ci.slug | replace("-", "_") -%}
     {% if ci | is_image -%}
     image_name_{{ py_slug }} = get_image_name(
+            values=job["inputs"],
+            slug="{{ ci.slug }}",
+    )
+    {% endif -%}
+    {% if ci | is_file -%}
+    file_name_{{ py_slug }} = get_file_name(
             values=job["inputs"],
             slug="{{ ci.slug }}",
     )
@@ -148,6 +154,20 @@ def get_image_name(*, values, slug):
     raise RuntimeError(f"Image with interface {slug} not found!")
 {%- endif %}
 
+{%- if cookiecutter.phase.algorithm_inputs | has_file %}
+def get_file_name(*, values, slug):
+    # This tells us the user-provided name of the input file
+    for value in values:
+        if value["interface"]["slug"] == slug:
+            file_url = value["file"]
+            pattern = r'[^/]+$'
+            match = re.search(pattern, file_url)
+            if match:
+                return match.group()
+            else:
+                raise RuntimeError("Could not parse filename.")
+    raise RuntimeError(f"Image with interface {slug} not found!")
+{%- endif %}
 
 def get_interface_relative_path(*, values, slug):
     # Gets the location of the interface relative to the input or output

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/evaluate.py.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/evaluate.py.j2
@@ -169,7 +169,7 @@ def get_file_name(*, values, slug):
                 return match.group()
             else:
                 raise RuntimeError("Could not parse filename.")
-    raise RuntimeError(f"Image with interface {slug} not found!")
+    raise RuntimeError(f"File with interface {slug} not found!")
 {%- endif %}
 
 def get_interface_relative_path(*, values, slug):

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/evaluate.py.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/evaluate.py.j2
@@ -22,6 +22,9 @@ import json
 from glob import glob
 import SimpleITK
 {%- endif %}
+{% if cookiecutter.phase.algorithm_inputs | has_image -%}
+import re
+{%- endif %}
 import random
 from statistics import mean
 from pathlib import Path


### PR DESCRIPTION
Small fix that I came across while onboarding CVS. 

The forge didn't generate an import function for file type interfaces and didn't extract the original file name for file type inputs. 

This PR adds those to the templates. I think it's fine to just use a generic "load_file()" function and leave it up to the challenge admins to customize that for their specific file type. 