### PR TITLE
Interoperability fixes (Mac OS)

### DIFF
--- a/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/save.sh.j2
+++ b/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/save.sh.j2
@@ -22,7 +22,7 @@ if [ -z "$build_timestamp" ]; then
 fi
 
 # Format the build information to remove special characters
-formatted_build_info=$(date -d "$build_timestamp" +"%Y%m%d_%H%M%S")
+formatted_build_info=$(echo $build_timestamp | sed -E 's/(.*)T(.*)\..*Z/\1_\2/' | sed 's/[-,:]/-/g')
 
 # Set the output filename with timestamp and build information
 output_filename="${SCRIPT_DIR}/${container_tag}_${formatted_build_info}.tar.gz"

--- a/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/test_run.sh.j2
+++ b/grand_challenge_forge/partials/example-algorithm/example-algorithm{{cookiecutter._}}/test_run.sh.j2
@@ -53,8 +53,8 @@ docker volume rm "$DOCKER_NOOP_VOLUME" > /dev/null
 # This allows the host user (e.g. you) to access and handle these files
 docker run --rm \
     --quiet \
-    --env HOST_UID=`id --user` \
-    --env HOST_GID=`id --group` \
+    --env HOST_UID=`id -u` \
+    --env HOST_GID=`id -g` \
     --volume "$OUTPUT_DIR":/output \
     alpine:latest \
     /bin/sh -c 'chown -R ${HOST_UID}:${HOST_GID} /output'

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/save.sh.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/save.sh.j2
@@ -22,7 +22,7 @@ if [ -z "$build_timestamp" ]; then
 fi
 
 # Format the build information to remove special characters
-formatted_build_info=$(date -d "$build_timestamp" +"%Y%m%d_%H%M%S")
+formatted_build_info=$(echo $build_timestamp | sed -E 's/(.*)T(.*)\..*Z/\1_\2/' | sed 's/[-,:]/-/g')
 
 # Set the output filename with timestamp and build information
 output_filename="${SCRIPT_DIR}/${container_tag}_${formatted_build_info}.tar.gz"

--- a/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/test_run.sh.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/example-evaluation-method{{cookiecutter._}}/test_run.sh.j2
@@ -54,8 +54,8 @@ docker volume rm "$DOCKER_NOOP_VOLUME" > /dev/null
 # This allows the host user (e.g. you) to access and handle these files
 docker run --rm \
     --quiet \
-    --env HOST_UID=`id --user` \
-    --env HOST_GID=`id --group` \
+    --env HOST_UID=`id -u` \
+    --env HOST_GID=`id -g` \
     --volume "$OUTPUT_DIR":/output \
     alpine:latest \
     /bin/sh -c 'chown -R ${HOST_UID}:${HOST_GID} /output'


### PR DESCRIPTION
We don't fully support Mac OS env but I've seen a few challenge admins stub their toe against these. A small effort to fix these.

The `date` and `id` binary interfaces seem different for a Mac OS environment. The binary  `sed` is, I hope, more universal. Quick test on an in-house Mac OS suggests this works.