### PR TITLE
Fix permissions on bash scripts

### DIFF
--- a/grand_challenge_forge/partials/algorithm-template/.gitattributes
+++ b/grand_challenge_forge/partials/algorithm-template/.gitattributes
@@ -1,4 +1,3 @@
 # sh (and their template counter parts) should always be lf their line endings
 *.sh text=lf eol=lf
 *.sh.j2 text=lf eol=lf
-resources/* filter=lfs diff=lfs merge=lfs -text

--- a/grand_challenge_forge/partials/docker-bash-scripts/do_test_run.sh.j2
+++ b/grand_challenge_forge/partials/docker-bash-scripts/do_test_run.sh.j2
@@ -16,6 +16,21 @@ DOCKER_NOOP_VOLUME="${DOCKER_IMAGE_TAG}-volume"
 INPUT_DIR="${SCRIPT_DIR}/test/input"
 OUTPUT_DIR="${SCRIPT_DIR}/test/output"
 
+echo "=+= (Re)build the container"
+source "${SCRIPT_DIR}/do_build.sh" "$DOCKER_IMAGE_TAG"
+
+cleanup() {
+    echo "=+= Cleaning permissions ..."
+    # Ensure permissions are set correctly on the output
+    # This allows the host user (e.g. you) to access and handle these files
+    docker run --rm \
+      --quiet \
+      --volume "$OUTPUT_DIR":/output \
+      --entrypoint /bin/sh \
+      $DOCKER_IMAGE_TAG \
+      -c "chmod -R -f o+rwX /output/* || true"
+}
+
 
 echo "=+= Cleaning up any earlier output"
 if [ -d "$OUTPUT_DIR" ]; then
@@ -27,10 +42,7 @@ else
   mkdir -m o+rwx "$OUTPUT_DIR"
 fi
 
-
-echo "=+= (Re)build the container"
-source "${SCRIPT_DIR}/do_build.sh" "$DOCKER_IMAGE_TAG"
-
+trap cleanup EXIT
 
 echo "=+= Doing a forward pass"
 ## Note the extra arguments that are passed here:


### PR DESCRIPTION
Closes #59 


Instead of relying on the omnipotence of Docker root, use the user in the original creation container to correctly set the rights of the output content so they can be overwritten/removed.