### PR TITLE
Ensure lower-case forged root directories

### DIFF
--- a/grand_challenge_forge/forge.py
+++ b/grand_challenge_forge/forge.py
@@ -34,10 +34,8 @@ def generate_challenge_pack(
         "grand-challenge-forge"
     )
 
-    challenge_slug = context['challenge']['slug']
-    pack_path = (
-        output_path / f"{challenge_slug.lower()}-challenge-pack"
-    )
+    challenge_slug = context["challenge"]["slug"]
+    pack_path = output_path / f"{challenge_slug.lower()}-challenge-pack"
 
     if pack_path.exists():
         _handle_existing(pack_path, delete_existing=delete_existing)

--- a/grand_challenge_forge/forge.py
+++ b/grand_challenge_forge/forge.py
@@ -34,8 +34,9 @@ def generate_challenge_pack(
         "grand-challenge-forge"
     )
 
+    challenge_slug = context['challenge']['slug']
     pack_path = (
-        output_path / f"{context['challenge']['slug'].lower()}-challenge-pack"
+        output_path / f"{challenge_slug.lower()}-challenge-pack"
     )
 
     if pack_path.exists():
@@ -268,9 +269,9 @@ def generate_algorithm_template(
         "grand-challenge-forge"
     )
 
-    algorithm_slug = context["algorithm"]["slug"].lower()
+    algorithm_slug = context["algorithm"]["slug"]
 
-    template_path = output_path / f"{algorithm_slug}-template"
+    template_path = output_path / f"{algorithm_slug.lower()}-template"
 
     if template_path.exists():
         _handle_existing(template_path, delete_existing=delete_existing)

--- a/grand_challenge_forge/forge.py
+++ b/grand_challenge_forge/forge.py
@@ -34,7 +34,9 @@ def generate_challenge_pack(
         "grand-challenge-forge"
     )
 
-    pack_path = output_path / f"{context['challenge']['slug']}-challenge-pack"
+    pack_path = (
+        output_path / f"{context['challenge']['slug'].lower()}-challenge-pack"
+    )
 
     if pack_path.exists():
         _handle_existing(pack_path, delete_existing=delete_existing)
@@ -266,7 +268,7 @@ def generate_algorithm_template(
         "grand-challenge-forge"
     )
 
-    algorithm_slug = context["algorithm"]["slug"]
+    algorithm_slug = context["algorithm"]["slug"].lower()
 
     template_path = output_path / f"{algorithm_slug}-template"
 


### PR DESCRIPTION
A `slug` in GC can sometimes be uppercase (e.g. `'CURVAS'`). This sometimes leads to GitHub repositories with uppercase letters, which is frowned upon.