### PR TITLE
Use example values for JSON interfaces in examples

### DIFF
--- a/grand_challenge_forge/partials/algorithm-template/inference.py.j2
+++ b/grand_challenge_forge/partials/algorithm-template/inference.py.j2
@@ -64,7 +64,8 @@ def run():
     # For now, let us make bogus predictions
     {%- for ci in algorithm.outputs %}
     output_{{ ci.slug.replace("-", "_")}} =
-        {%- if ci | is_image %} numpy.eye(4, 2)
+        {%- if ci | has_example_value %} {{ ci.example_value }}
+        {%- elif ci | is_image %} numpy.eye(4, 2)
         {%- elif ci | is_json %} {"content": "should match the required format"}
         {%- elif ci | is_file %} "content: should match the required format"
         {% endif %}

--- a/grand_challenge_forge/partials/example-algorithm/inference.py.j2
+++ b/grand_challenge_forge/partials/example-algorithm/inference.py.j2
@@ -62,7 +62,8 @@ def run():
     # For now, let us make bogus predictions
     {%- for ci in phase.algorithm_outputs %}
     output_{{ ci.slug.replace("-", "_")}} =
-        {%- if ci | is_image %} numpy.eye(4, 2)
+        {%- if ci | has_example_value %} {{ ci.example_value }}
+        {%- elif ci | is_image %} numpy.eye(4, 2)
         {%- elif ci | is_json %} {"content": "should match the required format"}
         {%- elif ci | is_file %} "content: should match the required format"
         {% endif %}

--- a/grand_challenge_forge/partials/filters.py
+++ b/grand_challenge_forge/partials/filters.py
@@ -36,3 +36,8 @@ def is_file(arg):
 @register_simple_filter
 def has_file(arg):
     return any(generation_utils.is_file(item) for item in arg)
+
+
+@register_simple_filter
+def has_example_value(arg):
+    return generation_utils.has_example_value(arg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ python = ">3.10"
 jinja2 = "*"
 click = "*"
 jsonschema = "*"
+black = "23.9.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,25 +38,29 @@ DEFAULT_PACK_CONTEXT_STUB = {
                         "slug": "input-ci-slug",
                         "kind": "Segmentation",
                         "super_kind": "Image",
-                        "relative_path": "images/input-value"
+                        "relative_path": "images/input-value",
+                        "example_value": None
                     },
                     {
                         "slug": "another-input-ci-slug",
                         "kind": "Anything",
                         "super_kind": "File",
-                        "relative_path": "another-input-value.json"
+                        "relative_path": "another-input-value.json",
+                        "example_value": {"key": "value"}
                     },
                     {
                         "slug": "yet-another-input-ci-slug",
                         "kind": "Anything",
                         "super_kind": "Value",
-                        "relative_path": "yet-another-input-value.json"
+                        "relative_path": "yet-another-input-value.json",
+                        "example_value": {"key": "value"}
                     },
                     {
                         "slug": "yet-another-non-json-input-ci-slug",
                         "kind": "Anything",
                         "super_kind": "File",
-                        "relative_path": "yet-another-non-json-input-value"
+                        "relative_path": "yet-another-non-json-input-value",
+                        "example_value": None
                     }
                 ],
                 "algorithm_outputs": [
@@ -64,25 +68,29 @@ DEFAULT_PACK_CONTEXT_STUB = {
                         "slug": "output-ci-slug",
                         "kind": "Image",
                         "super_kind": "Image",
-                        "relative_path": "images/output-value"
+                        "relative_path": "images/output-value",
+                        "example_value": None
                     },
                     {
                         "slug": "another-output-ci-slug",
                         "kind": "Anything",
                         "super_kind": "File",
-                        "relative_path": "output-value.json"
+                        "relative_path": "output-value.json",
+                        "example_value": {"key": "value"}
                     },
                     {
                         "slug": "yet-another-output-ci-slug",
                         "kind": "Anything",
                         "super_kind": "Value",
-                        "relative_path": "yet-another-output-value.json"
+                        "relative_path": "yet-another-output-value.json",
+                        "example_value": {"key": "value"}
                     },
                     {
                         "slug": "yet-another-non-json-output-ci-slug",
                         "kind": "Anything",
                         "super_kind": "File",
-                        "relative_path": "yet-another-non-json-output-value"
+                        "relative_path": "yet-another-non-json-output-value",
+                        "example_value": None
                     }
                 ]
             },
@@ -97,7 +105,8 @@ DEFAULT_PACK_CONTEXT_STUB = {
                         "slug": "input-ci-slug",
                         "kind": "Image",
                         "super_kind": "Image",
-                        "relative_path": "images/input-value"
+                        "relative_path": "images/input-value",
+                        "example_value": None
                     }
                 ],
                 "algorithm_outputs": [
@@ -105,7 +114,8 @@ DEFAULT_PACK_CONTEXT_STUB = {
                         "slug": "another-output-ci-slug",
                         "kind": "Anything",
                         "super_kind": "File",
-                        "relative_path": "output-value.json"
+                        "relative_path": "output-value.json",
+                        "example_value": {"key": "value"}
                     }
                 ]
             }
@@ -124,25 +134,29 @@ DEFAULT_ALGORITHM_CONTEXT_STUB = {
                 "slug": "input-ci-slug",
                 "kind": "Segmentation",
                 "super_kind": "Image",
-                "relative_path": "images/input-value"
+                "relative_path": "images/input-value",
+                "example_value": None
             },
             {
                 "slug": "another-input-ci-slug",
                 "kind": "Anything",
                 "super_kind": "File",
-                "relative_path": "another-input-value.json"
+                "relative_path": "another-input-value.json",
+                "example_value": {"key": "value"}
             },
             {
                 "slug": "yet-another-input-ci-slug",
                 "kind": "Anything",
                 "super_kind": "Value",
-                "relative_path": "yet-another-input-value.json"
+                "relative_path": "yet-another-input-value.json",
+                "example_value": {"key": "value"}
             },
             {
                 "slug": "yet-another-non-json-input-ci-slug",
                 "kind": "Anything",
                 "super_kind": "File",
-                "relative_path": "yet-another-non-json-input-value"
+                "relative_path": "yet-another-non-json-input-value",
+                "example_value": None
             }
         ],
         "outputs": [
@@ -150,25 +164,29 @@ DEFAULT_ALGORITHM_CONTEXT_STUB = {
                 "slug": "output-ci-slug",
                 "kind": "Image",
                 "super_kind": "Image",
-                "relative_path": "images/output-value"
+                "relative_path": "images/output-value",
+                "example_value": None
             },
             {
                 "slug": "another-output-ci-slug",
                 "kind": "Anything",
                 "super_kind": "File",
-                "relative_path": "output-value.json"
+                "relative_path": "output-value.json",
+                "example_value": {"key": "value"}
             },
             {
                 "slug": "yet-another-output-ci-slug",
                 "kind": "Anything",
                 "super_kind": "Value",
-                "relative_path": "yet-another-output-value.json"
+                "relative_path": "yet-another-output-value.json",
+                "example_value": {"key": "value"}
             },
             {
                 "slug": "yet-another-non-json-output-ci-slug",
                 "kind": "Anything",
                 "super_kind": "File",
-                "relative_path": "yet-another-non-json-output-value"
+                "relative_path": "yet-another-non-json-output-value",
+                "example_value": None
             }
         ]
     }


### PR DESCRIPTION
Part of the pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/338

This PR uses the example values that @ammar257ammar nicely added for JSON CIVs. In theory, this makes every example now viable for direct upload.

It uses the example values:
- For input values for algorithms
- For output values for algorithms
- For fictive algorithm output for local tests of evaluation methods
- For values for value-kind CIVs in prediction.json of evaluation methods

To address formatting of very long example values (e.g. polygons/2D Bounding Boxes) all rendered/copied partial templates are now also covered by `black`. This has the nice benefit of cleaning up the formatting of the generated examples.