### PR TITLE
Revert "Ensure lower-case forged root directories"

### DIFF
--- a/grand_challenge_forge/forge.py
+++ b/grand_challenge_forge/forge.py
@@ -34,8 +34,7 @@ def generate_challenge_pack(
         "grand-challenge-forge"
     )
 
-    challenge_slug = context["challenge"]["slug"]
-    pack_path = output_path / f"{challenge_slug.lower()}-challenge-pack"
+    pack_path = output_path / f"{context['challenge']['slug']}-challenge-pack"
 
     if pack_path.exists():
         _handle_existing(pack_path, delete_existing=delete_existing)
@@ -269,7 +268,7 @@ def generate_algorithm_template(
 
     algorithm_slug = context["algorithm"]["slug"]
 
-    template_path = output_path / f"{algorithm_slug.lower()}-template"
+    template_path = output_path / f"{algorithm_slug}-template"
 
     if template_path.exists():
         _handle_existing(template_path, delete_existing=delete_existing)


### PR DESCRIPTION
Reverts DIAGNijmegen/rse-grand-challenge-forge#64

This will break the fixes in https://github.com/comic/grand-challenge.org/commit/ed07a16ebf3f9e3cf6a5579c4065ed7fbc709640

The capitalisation of slugs should not be messed with.