### PR TITLE
Remove redundant permission docker run

### DIFF
--- a/grand_challenge_forge/partials/docker-bash-scripts/do_test_run.sh.j2
+++ b/grand_challenge_forge/partials/docker-bash-scripts/do_test_run.sh.j2
@@ -37,6 +37,7 @@ echo "=+= Cleaning up any earlier output"
 if [ -d "$OUTPUT_DIR" ]; then
   # Ensure permissions are setup correctly
   # This allows for the Docker user to write to this location
+  ls -lDR "${OUTPUT_DIR}"
   rm -rf "${OUTPUT_DIR}"/*
 else
   mkdir "$OUTPUT_DIR"

--- a/grand_challenge_forge/partials/docker-bash-scripts/do_test_run.sh.j2
+++ b/grand_challenge_forge/partials/docker-bash-scripts/do_test_run.sh.j2
@@ -34,9 +34,13 @@ cleanup() {
 
 
 echo "=+= Cleaning up any earlier output"
+
+
 if [ -d "$OUTPUT_DIR" ]; then
   # Ensure permissions are setup correctly
   # This allows for the Docker user to write to this location
+  echo "prior to cleaning: permissions"
+  ls -alhR "$OUTPUT_DIR"
   rm -rf "${OUTPUT_DIR}"/*
   chmod -f o+rwx "$OUTPUT_DIR"
 else

--- a/grand_challenge_forge/partials/docker-bash-scripts/do_test_run.sh.j2
+++ b/grand_challenge_forge/partials/docker-bash-scripts/do_test_run.sh.j2
@@ -69,16 +69,6 @@ docker run --rm \
     $DOCKER_IMAGE_TAG
 docker volume rm "$DOCKER_NOOP_VOLUME" > /dev/null
 
-# Ensure permissions are set correctly on the output
-# This allows the host user (e.g. you) to access and handle these files
-docker run --rm \
-    --quiet \
-    --env HOST_UID=`id -u` \
-    --env HOST_GID=`id -g` \
-    --volume "$OUTPUT_DIR":/output \
-    alpine:latest \
-    /bin/sh -c 'chown -R ${HOST_UID}:${HOST_GID} /output'
-
 echo "=+= Wrote results to ${OUTPUT_DIR}"
 
 echo "=+= Save this image for uploading via ./do_save.sh \"${DOCKER_IMAGE_TAG}\""

--- a/grand_challenge_forge/partials/docker-bash-scripts/do_test_run.sh.j2
+++ b/grand_challenge_forge/partials/docker-bash-scripts/do_test_run.sh.j2
@@ -29,23 +29,19 @@ cleanup() {
       --volume "$OUTPUT_DIR":/output \
       --entrypoint /bin/sh \
       $DOCKER_IMAGE_TAG \
-      -c "chmod -R -f o+rwX /output/* || true"
+      -c "chmod -R -f o-t+rwX /output/* || true"
 }
 
-
 echo "=+= Cleaning up any earlier output"
-
 
 if [ -d "$OUTPUT_DIR" ]; then
   # Ensure permissions are setup correctly
   # This allows for the Docker user to write to this location
-  echo "prior to cleaning: permissions"
-  ls -alhR "$OUTPUT_DIR"
   rm -rf "${OUTPUT_DIR}"/*
-  chmod -f o+rwx "$OUTPUT_DIR"
 else
-  mkdir -m o+rwx "$OUTPUT_DIR"
+  mkdir "$OUTPUT_DIR"
 fi
+chmod -f o-t+rwx "$OUTPUT_DIR"
 
 trap cleanup EXIT
 

--- a/grand_challenge_forge/partials/docker-bash-scripts/do_test_run.sh.j2
+++ b/grand_challenge_forge/partials/docker-bash-scripts/do_test_run.sh.j2
@@ -29,20 +29,26 @@ cleanup() {
       --volume "$OUTPUT_DIR":/output \
       --entrypoint /bin/sh \
       $DOCKER_IMAGE_TAG \
-      -c "chmod -R -f o-t+rwX /output/* || true"
+      -c "chmod -R -f o+rwX /output/* || true"
 }
-
-echo "=+= Cleaning up any earlier output"
 
 if [ -d "$OUTPUT_DIR" ]; then
   # Ensure permissions are setup correctly
   # This allows for the Docker user to write to this location
-  ls -lDR "${OUTPUT_DIR}"
-  rm -rf "${OUTPUT_DIR}"/*
+  chmod -f o+rwx "$OUTPUT_DIR"
+
+  echo "=+= Cleaning up any earlier output"
+  # Use the container itself to circumvent ownership problems
+  docker run --rm \
+      --platform=linux/amd64 \
+      --quiet \
+      --volume "$OUTPUT_DIR":/output \
+      --entrypoint /bin/sh \
+      $DOCKER_IMAGE_TAG \
+      -c "rm -rf /output/* || true"
 else
-  mkdir "$OUTPUT_DIR"
+  mkdir -m o+rwx "$OUTPUT_DIR"
 fi
-chmod -f o-t+rwx "$OUTPUT_DIR"
 
 trap cleanup EXIT
 


### PR DESCRIPTION
This is already done by the exit TRAP, in a less extreme manner.