### PR TITLE
Include get_file_name if algorithm inputs include files

### DIFF
--- a/grand_challenge_forge/partials/example-evaluation-method/evaluate.py.j2
+++ b/grand_challenge_forge/partials/example-evaluation-method/evaluate.py.j2
@@ -274,7 +274,7 @@ def get_image_name(*, values, slug):
 {%- endif %}
 
 
-{%- if algorithm_output_sockets | has_file or phase.evaluation_additional_inputs | has_file %}
+{%- if algorithm_input_sockets | has_file or phase.evaluation_additional_inputs | has_file %}
 def get_file_name(*, values, slug):
     # This tells us the user-provided name of the input file
     for value in values:


### PR DESCRIPTION
Closes https://github.com/DIAGNijmegen/rse-grand-challenge-forge/issues/97

I think there is no need to check for `algorithm_outputs` when deciding whether or not to include `get_file_name`, so changed it to inputs rather than extending the check to include both. 